### PR TITLE
Added file-based authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ pip install requirements.txt
 URL can be any of the following ip:port, plex.direct:port, hostname:port, plex.tv
 
 ```
-usage: main.py [-h] -u USERNAME -p PASSWORD url
+usage: main.py [-h] [-u USERNAME] [-p PASSWORD] [-c COOKIE] [--original-filename] [-t TOKEN] [-f AUTHFILE] url
 
 positional arguments:
   url                   URL to Movie, Show, Season, Episode.
@@ -41,10 +41,25 @@ optional arguments:
   --original-filename   Name content by original name
   -t TOKEN, --token TOKEN
                         Plex Token
+  -f AUTHFILE, --authfile AUTHFILE
+                        Path to a json file containing authentication data
 ```
 
-## Example
+## Examples
 
 ```
 python main.py -u codedninja -p 3U7qYhaBAk8yfa 'https://app.plex.tv/desktop#!/server/0893cadc04a6f52efa052691d6a07c5b54890ca1/details?key=%2Flibrary%2Fmetadata%2F208649&context=source%3Ahub.tv.recentlyaired'
 ```
+
+```
+python main.py -f auth.json 'https://app.plex.tv/desktop#!/server/0893cadc04a6f52efa052691d6a07c5b54890ca1/details?key=%2Flibrary%2Fmetadata%2F208649&context=source%3Ahub.tv.recentlyaired'
+```
+
+Content of `auth.json` :
+```json
+{
+    "email": "codedninja",
+    "password": "3U7qYhaBAk8yfa"
+}
+```
+


### PR DESCRIPTION
Added an option (`-f`) that loads the credentials from a json file. The file will be loaded if the arguments provided to the script aren't enough to authenticate the user. The json object can have any of the following four fields : `email`, `password`, `token` or `cookie`. For instance : 
```json
{
    "token": "oCyymtQ8RsSM1eAS"
}
```
It will make it easier to launch the script and more safe since the credentials won't be logged in the command line history.
Also, if the script can't authenticate the user, it will now prompt for a username and password in the command line.